### PR TITLE
 Enhance capability to return an error response with data

### DIFF
--- a/src/attemptRefresh.js
+++ b/src/attemptRefresh.js
@@ -108,7 +108,6 @@ export const createFSAConverter = (successType, failureType) => {
     if (!response.ok) {
 
       if (
-        emptyCodes.indexOf(response.status) === -1 &&
         contentType &&
         contentType.indexOf("json") !== -1
       ) {

--- a/src/attemptRefresh.js
+++ b/src/attemptRefresh.js
@@ -102,19 +102,37 @@ const defaultIsRefreshCall = (action, refreshAction) => {
 
 export const createFSAConverter = (successType, failureType) => {
   return response => {
-    if (!response.ok) {
-      return {
-        error: true,
-        payload: {
-          status: response.status
-        },
-        type: failureType
-      }
-    }
-
     const contentType = response.headers.get("Content-Type");
     const emptyCodes = [204, 205];
 
+    if (!response.ok) {
+
+      if (
+        emptyCodes.indexOf(response.status) === -1 &&
+        contentType &&
+        contentType.indexOf("json") !== -1
+      ) {
+        const creatFailureType = async (response) => ({
+          payload: {
+            status: response.status,
+            ... await response.json()
+          },
+          error: true,
+          type: failureType
+        })
+
+        return creatFailureType(response)
+      } else {
+        return {
+          error: true,
+          payload: {
+            status: response.status
+          },
+          type: failureType
+        }
+      }
+    }
+  
     const createSuccessType = payload => ({
       payload,
       type: successType

--- a/src/attemptRefresh.js
+++ b/src/attemptRefresh.js
@@ -102,7 +102,7 @@ const defaultIsRefreshCall = (action, refreshAction) => {
 
 export const createFSAConverter = (successType, failureType) => {
   return response => {
-    const contentType = response.headers.get("Content-Type");
+    const contentType = response.headers && response.headers.get("Content-Type");
     const emptyCodes = [204, 205];
 
     if (!response.ok) {
@@ -111,14 +111,22 @@ export const createFSAConverter = (successType, failureType) => {
         contentType &&
         contentType.indexOf("json") !== -1
       ) {
-        const creatFailureType = async (response) => ({
-          payload: {
-            status: response.status,
-            ... await response.json()
-          },
-          error: true,
-          type: failureType
-        })
+        
+        const creatFailureType = async (response) => {
+          const jsonResponse = await response.json();
+          const payload =
+            Object.assign({
+                status: response.status
+              },
+              jsonResponse
+            );
+
+          return {
+            payload,
+            error: true,
+            type: failureType
+          };
+        }
 
         return creatFailureType(response)
       } else {


### PR DESCRIPTION
When a client post an unique id twice and the server response with 409 conflict it should be possible to return the id which cause the conflict.